### PR TITLE
Ignore end of lines (LF/CRLF)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,6 @@
     "quotes": [2, "double"], // we may need to copy this to an actual .eslintrc
     "quote-props": 0, // same reason...
     "no-magic-numbers": 0, // because rules are 0, 1, 2
-    "indent": ["error", 2],
-    "linebreak-style": 0 // ensure compatibility with Windows systems ignoring LF/CRLF end of lines
+    "indent": ["error", 2]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "quotes": [2, "double"], // we may need to copy this to an actual .eslintrc
     "quote-props": 0, // same reason...
     "no-magic-numbers": 0, // because rules are 0, 1, 2
-    "indent": ["error", 2]  
+    "indent": ["error", 2],
+    "linebreak-style": 0 // ensure compatibility with Windows systems ignoring LF/CRLF end of lines
   }
 }

--- a/overrides.js
+++ b/overrides.js
@@ -5,6 +5,7 @@ module.exports = {
   },
   "extends": "airbnb-base",
   "rules": {
+    "linebreak-style": 0, // ensure compatibility with Windows systems ignoring LF/CRLF end of lines
     "brace-style": ["error", "1tbs"],
     "comma-dangle": ["error", "never"],
     "func-names": 0,


### PR DESCRIPTION
With the increase of Windows systems working in different projects (mostly in Colab). It is very tedious to have or local version of lint with this rule which it has to be stashed in order to sync with the main repository or have to commit all the Js files in a project with LF.
